### PR TITLE
Updated to support Grunt 0.4.0rc4

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,12 +3,6 @@ module.exports = function(grunt) {
 	'use strict';
 
 	grunt.initConfig({
-		lint: {
-			files: [
-				'tasks/webfont.js',
-				'grunt.js'
-			]
-		},
 		webfont: {
 			test1: {
 				files: 'test/src/*.svg',
@@ -23,10 +17,11 @@ module.exports = function(grunt) {
 				stylesheet: 'bootstrap'
 			}
 		},
-		test: {
-			tasks: ['test/*_test.js']
+		nodeunit: {
+			all: ['test/webfont_test.js']
 		},
 		jshint: {
+      all: ['Gruntfile.js', 'tasks/*.js', 'test/*.js'],
 			options: {
 				node: true,
 				white: false,
@@ -45,12 +40,15 @@ module.exports = function(grunt) {
 	var fs = require('fs');
 
 	grunt.registerTask('clean', 'Copy files to test.', function() {
-		grunt.file.expand('test/tmp/**').forEach(function(file) {
+		grunt.file.expand('test/tmp/**.*').forEach(function(file) {
 			fs.unlinkSync(file);
 		});
 		fs.rmdirSync('test/tmp');
 	});
 
-	grunt.registerTask('default', 'lint clean webfont test clean');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+
+	grunt.registerTask('default', ['clean', 'webfont', 'nodeunit', 'jshint']);
 
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "temp": "0.4.x"
   },
   "devDependencies": {
-    "grunt": "*"
+    "grunt": "0.4.0rc4",
+    "grunt-contrib-jshint": "https://github.com/gruntjs/grunt-contrib-jshint/archive/7fd70e86c5a8d489095fa81589d95dccb8eb3a46.tar.gz",
+    "grunt-contrib-nodeunit": "git+ssh://git@github.com/gruntjs/grunt-contrib-nodeunit.git#f4d2bdb3b03049bb435f22e2fdafd677f211c0e2"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
 	var fs = require('fs'),
 		path = require('path'),
 		temp = require('temp'),
-		async = grunt.utils.async;
+		async = grunt.util.async;
 
 	grunt.registerMultiTask('webfont', 'Compile separate SVG files to webfont', function() {
 		this.requiresConfig([ this.name, this.target, 'files' ].join('.'));
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
 			stylesheetType = params.stylesheet || 'bem',
 			styles = optionToArray(params.styles, 'font,icon'),
 			types = optionToArray(params.types, 'woff,ttf,eot,svg');
-		
+
 		var fontfaceStyles = styles.indexOf('font') !== -1,
 			baseStyles = styles.indexOf('icon') !== -1,
 			extraStyles = styles.indexOf('extra') !== -1;
@@ -85,7 +85,7 @@ module.exports = function(grunt) {
 				];
 				if (addHashes) args.push('--hashes');
 
-				grunt.utils.spawn({
+				grunt.util.spawn({
 					cmd: 'fontforge',
 					args: args
 				}, function(err, json, code) {
@@ -108,7 +108,10 @@ module.exports = function(grunt) {
 			// Write CSS and HTML
 			function(done) {
 				// CSS
-				var context = {
+				var context = {},
+					options = {};
+
+				context = {
 					fontBaseName: fontBaseName,
 					fontName: fontName,
 					fontfaceStyles: fontfaceStyles,
@@ -117,10 +120,13 @@ module.exports = function(grunt) {
 					iconsStyles: true,
 					glyphs: glyphs
 				};
+
+				options.data = context;
+
 				var cssTemplateFile = path.join(__dirname, 'templates/' + stylesheetType + '.css'),
 					cssFile = path.join(destDir, fontBaseName + '.css'),
 					cssTemplate = fs.readFileSync(cssTemplateFile, 'utf8'),
-					css = grunt.template.process(cssTemplate, context);
+					css = grunt.template.process(cssTemplate, options);
 				grunt.file.write(cssFile, css);
 
 				// Demo HTML
@@ -130,11 +136,11 @@ module.exports = function(grunt) {
 				context.iconsStyles = false;
 				context.baseClass = stylesheetType === 'bem' ? 'icon' : '';
 				context.classPrefix = 'icon' + (stylesheetType === 'bem' ? '_' : '-');
-				context.styles = grunt.template.process(cssTemplate, context);
+				context.styles = grunt.template.process(cssTemplate, options);
 				var demoTemplateFile = path.join(__dirname, 'templates/demo.html'),
 					demoFile = path.join(destDir, fontBaseName + '.html'),
 					demoTemplate = fs.readFileSync(demoTemplateFile, 'utf8'),
-					demo = grunt.template.process(demoTemplate, context);
+					demo = grunt.template.process(demoTemplate, options);
 				grunt.file.write(demoFile, demo);
 
 				done();

--- a/test/webfont_test.js
+++ b/test/webfont_test.js
@@ -13,7 +13,7 @@ exports.webfont = {
 			test.ok(grunt.file.read('test/tmp/icons.' + type).length, name + ' file not empty.');
 		});
 
-		var svgs = grunt.file.expand('test/src/**'),
+		var svgs = grunt.file.expand('test/src/**.*'),
 			css = grunt.file.read('test/tmp/icons.css');
 
 		// Every SVG file should have corresponding entry in CSS file
@@ -51,7 +51,7 @@ exports.webfont = {
 			test.ok(!fs.existsSync(prefix + type), name + ' file NOT created.');
 		});
 
-		var svgs = grunt.file.expand('test/src/**'),
+		var svgs = grunt.file.expand('test/src/**.*'),
 			css = grunt.file.read('test/tmp/myfont.css');
 
 		// Every SVG file should have corresponding entry in CSS file


### PR DESCRIPTION
This pull request supports Grunt 0.4.0rc4. All tests pass.
1. Changed grunt.utils to grunt.util
   - Grunt's utils was renamed to util as per https://github.com/gruntjs/grunt/commit/c3931bd807d81f25ca8f431b2e543f90ee610cc2#lib/grunt
2. Sent the existing template object context wrapped in a new object with key data
   - Grunt updated their template.process method
     https://github.com/gruntjs/grunt/commit/451c75fd79d5e68c3e4d72eeeafbc79632b0bcf6#lib/grunt

Also to note it appears grunt.file.expand now includes folders. I updated the tests to only include files.
