### PR TITLE
Native Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
 before_script:
   - sudo apt-get install fontforge eot-utils
   - wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
-  - unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/
+  - unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/ && cd ..
   - npm install -g grunt-cli
   - npm install
-script:
-  - grunt


### PR DESCRIPTION
Return to the good folder to make `npm test` found the `package.json` & so run the script.test correctly.
I got the same problem for another build & fix it like that.
