### PR TITLE
stop webfont from rejecting other tasks when no svg/eps files are given

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
 		// @todo Check that source files are svg or eps
 		var files = this.filesSrc;
 		if (!files.length) {
-			grunt.warn('Source SVG or EPS files not found.');
+			grunt.log.writeln('Source SVG or EPS files not found.'.grey);
 			allDone();
 		}
 


### PR DESCRIPTION
grunt.warn stops other grunt tasks without using --force...
moved it to grunt.log.writeln, because i think just informing that there are no files is enough, and other tasks can move on.
