### PR TITLE
fixed return statement when no src files are given

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
 		if (!files.length) {
 			grunt.log.writeln('Source SVG or EPS files not found.'.grey);
 			allDone();
+			return;
 		}
 
 		// @todo Check that all needed tools installed: fontforge, ttf2eot, ttfautohint, sfnt2woff


### PR DESCRIPTION
needed to add return; to the 'no files' section.
without it, livereload and regarde/watch would be killed every time grunt-webfont wants to compile src files...
