### PR TITLE
Align the readme with conventional github documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,7 +74,7 @@ Directory for resulting CSS files (if different than font directory).
 
 #### font
 
-Type: `string`
+Type: `string` Default: `icons`
 Name of font and base name of font files.
 
 #### hashes


### PR DESCRIPTION
I felt some kind of annoyed with the headlines in the documentation of the parameters. In this PR the headlines and the default values are separated for better readability.
