### PR TITLE
custom HTML demo template receives CSS options

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -237,14 +237,11 @@ module.exports = function(grunt) {
 					});
 					var htmlStyles = grunt.template.process(cssTemplate, {data: cssContext});
 
-					var htmlContext = {
-						fontBaseName: fontBaseName,
-						glyphs: glyphs,
+					var htmlContext = _.extend(cssContext, {
 						baseClass: syntax === 'bem' ? 'icon' : '',
 						classPrefix: 'icon' + (syntax === 'bem' ? '_' : '-'),
-						styles: htmlStyles,
-						ligatures: addLigatures
-					};
+						styles: htmlStyles
+					});
 
 					var demoTemplate = htmlDemoTemplate
 						? grunt.file.read(htmlDemoTemplate)


### PR DESCRIPTION
The html options received by a custom demo template were very limited. Right now it receives all the cssContext and it's more flexible.
