### PR TITLE
Webfont did not receive a popper JSON result

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -219,7 +219,15 @@ module.exports = function(grunt) {
 
 				// Trim fontforge result
 				var json = fontforgeProcess.stdout.replace(/^[^{]+/, '').replace(/[^}]+$/, '');
-				var result = JSON.parse(json);
+
+				// Parse json
+				var result;
+				try {
+					result = JSON.parse(json);
+				} catch (e) {
+					grunt.warn('Webfont did not receive a popper JSON result.\n' + e + '\n' + fontforgeProcess.stdout);
+				}
+
 				o.fontName = path.basename(result.file);
 				o.glyphs = result.names;
 


### PR DESCRIPTION
grunt-webfont crashed on my machine with a fatal error:

```
grunt
Running "webfont:icons" (webfont) task
Fatal error: Unexpected token P
```

further investigations  showed that the JSON value had a prefix (beginning with a P):

```
PythonUI_Init()
copyUIMethodsToBaseTable()
{"names": ["icon-social-twitter"], "file": "build/fonts/icons-f65c6f7c13c8dfaac01df545dcb55578"}
```

This pull request tries to remove prefixes and postfixes which fixes my problem.

**Bonus** - if there will be a similar bug in future the code would output a more verbose error message:

```
grunt
Running "webfont:icons" (webfont) task
Warning: Webfont did not receive a popper JSON result.
SyntaxError: Unexpected token P 
PythonUI_Init()
copyUIMethodsToBaseTable()
{"names": ["icon-social-twitter"], "file": "build/fonts/icons-f65c6f7c13c8dfaac01df545dcb55578"} Use --force to continue.
```
