### PR TITLE
Simplified less output

### DIFF
--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -25,12 +25,15 @@
 
 <% if (iconsStyles) { %>/* Icons */<% for (var glyphIdx = 0; glyphIdx < glyphs.length; glyphIdx++) { %>
 <% if (stylesheet === 'less') { %>
-.icon-<%= glyphs[glyphIdx] %> {
+.icon-<%= glyphs[glyphIdx] %>() {
 	&:before {
 		content:"<% if (addLigatures) { %><%= glyphs[glyphIdx] %><% } else { %>\<%= (61696+glyphIdx).toString(16) %><% } %>";
 	}
+}
+.icon_<%= glyphs[glyphIdx] %>{
+ 	.icon-<%= glyphs[glyphIdx] %>();
 }<% } else { %>
-.icon-<%= glyphs[glyphIdx] %>:before {
+.icon_<%= glyphs[glyphIdx] %>:before {
 	content:"<% if (addLigatures) { %><%= glyphs[glyphIdx] %><% } else { %>\<%= (61696+glyphIdx).toString(16) %><% } %>";
-}<% } %><% } } %>
+}<% } } } %>
 

--- a/tasks/templates/bem.json
+++ b/tasks/templates/bem.json
@@ -1,4 +1,4 @@
 {
 	"baseClass": "icon",
-	"classPrefix": "icon-"
+	"classPrefix": "icon_"
 }

--- a/test/webfont_test.js
+++ b/test/webfont_test.js
@@ -50,11 +50,11 @@ exports.webfont = {
 		svgs.forEach(function(file) {
 			var id = path.basename(file, '.svg');
 			test.ok(
-				find(css, '.icon-' + id + ':before'),
+				find(css, '.icon_' + id + ':before'),
 				'Icon ' + id + ' should be in CSS file.'
 			);
 			test.ok(
-				find(html, '<div class="icons__item" data-name="' + id + '"><i class="icon icon-' + id + '"></i> icon-' + id + '</div>'),
+				find(html, '<div class="icons__item" data-name="' + id + '"><i class="icon icon_' + id + '"></i> icon_' + id + '</div>'),
 				'Icon ' + id + ' should be in HTML file.'
 			);
 		});
@@ -234,7 +234,7 @@ exports.webfont = {
 		svgs.forEach(function(file) {
 			var id = path.basename(file, '.svg');
 			test.ok(
-				find(css, '.icon-' + id + ':before'),
+				find(css, '.icon_' + id + ':before'),
 				'Icon ' + id + ' should be in CSS file.'
 			);
 		});
@@ -318,7 +318,7 @@ exports.webfont = {
 		svgs.forEach(function(file) {
 			var id = path.basename(file, '.svg');
 			test.ok(
-				find(less, '.icon-' + id + ' {\n\t&:before'),
+				find(less, '.icon-' + id + '() {\n\t&:before'),
 				'LESS Mixin ' + id + ' should be in CSS file.'
 			);
 		});
@@ -376,7 +376,7 @@ exports.webfont = {
 		var css = grunt.file.read('test/tmp/spaces/icons.css');
 
 		test.ok(
-			find(css, '.icon-ma-il-ru:before'),
+			find(css, '.icon_ma-il-ru:before'),
 			'Spaces in class name should be replaced by hyphens.'
 		);
 
@@ -421,7 +421,7 @@ exports.webfont = {
 		svgs.forEach(function(file) {
 			var id = path.basename(file, '.svg');
 			test.ok(
-				find(html, '.icon-' + id + ':before'),
+				find(html, '.icon_' + id + ':before'),
 				'Icon ' + id + ' CSS should be in HTML file.'
 			);
 		});
@@ -437,7 +437,7 @@ exports.webfont = {
 		svgs.forEach(function(file) {
 			var id = path.basename(file, '.svg');
 			test.ok(
-				find(css, '.icon-' + id + ':before'),
+				find(css, '.icon_' + id + ':before'),
 				'Icon ' + id + ' should be in CSS file.'
 			);
 		});
@@ -469,7 +469,7 @@ exports.webfont = {
 		svgs.forEach(function(file) {
 			var id = [path.basename(path.dirname(file)), path.basename(file, '.svg')].join('-');
 			test.ok(
-				find(css, '.icon-' + id + ':before'),
+				find(css, '.icon_' + id + ':before'),
 				'Icon ' + id + ' should be in CSS file.'
 			);
 		});


### PR DESCRIPTION
The previous implementation of lesscss mix-ins was redundant. When compiled to CSS, it resulted in having both ".icon-name" and  ".icon_name" selectors.  Since any selector can be used as a mixin, this update removes the secondary CSS selectors in favor of the nested LESS notation if "less" is specified.  

The BEM template can (and does) now use "icon-" as a prefix in order to maintain consistency between syntaxes

Additionally, several spelling errors were corrected in webfont_test.js
