### PR TITLE
Understand templates of any extension

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -396,8 +396,10 @@ module.exports = function(grunt) {
 		}
 
 		function readTemplate(template, syntax, ext) {
+			var filename;
 			if (template) {
-				return grunt.file.read(template.replace(/\.css$/, ext));
+				filename = template.replace(/\.[^\\\/.]+$/, '') + ext;
+				return grunt.file.read(filename);
 			}
 			else {
 				return fs.readFileSync(path.join(__dirname, 'templates/' + syntax + ext), 'utf8');


### PR DESCRIPTION
The following pull request teaches grunt-webfont to generate proper JSON paths for templates of any extension:

```
some/path/template-file → some/path/template-file.json
some/path/template-file.scss → some/path/template-file.json
some/path/template-file.tpl.scss → some/path/template-file.tpl.json
```
