### PR TITLE
Hack in unicode mapping support.

### DIFF
--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -27,13 +27,25 @@
 <% if (stylesheet === 'less') { %>
 .<%= mixinPrefix %><%= glyphs[glyphIdx] %>() {
 	&:before {
-		content:"<% if (addLigatures) { %><%= glyphs[glyphIdx] %><% } else { %>\<%= (61696+glyphIdx).toString(16) %><% } %>";
+		content:"<% if (addLigatures) {
+			%><%= glyphs[glyphIdx] %><%
+		} else if (fontmap && fontmap[glyphs[glyphIdx]]) {
+			%>\<%= fontmap[glyphs[glyphIdx]] %><%
+		} else {
+			%>\<%= (61696+glyphIdx).toString(16) %><%
+		} %>";
 	}
 }
 .<%= classPrefix %><%= glyphs[glyphIdx] %>{
  	.<%= mixinPrefix %><%= glyphs[glyphIdx] %>();
 }<% } else { %>
 .<%= classPrefix %><%= glyphs[glyphIdx] %>:before {
-	content:"<% if (addLigatures) { %><%= glyphs[glyphIdx] %><% } else { %>\<%= (61696+glyphIdx).toString(16) %><% } %>";
+	content:"<% if (addLigatures) {
+		%><%= glyphs[glyphIdx] %><%
+	} else if (fontmap && fontmap[glyphs[glyphIdx]]) {
+		%>\<%= fontmap[glyphs[glyphIdx]] %><%
+	} else {
+		%>\<%= (61696+glyphIdx).toString(16) %><%
+	} %>";
 }<% } } } %>
 

--- a/tasks/templates/bootstrap.css
+++ b/tasks/templates/bootstrap.css
@@ -84,10 +84,22 @@ li[class*=" <%= classPrefix %>"].<%= classPrefix %>large:before {
 <% if (stylesheet === 'less') { %>
 .<%= classPrefix %><%= glyphs[glyphIdx] %> {
 	&:before {
-		content:"<% if (addLigatures) { %><%= glyphs[glyphIdx] %><% } else { %>\<%= (61696+glyphIdx).toString(16) %><% } %>";
+		content:"<% if (addLigatures) {
+			%><%= glyphs[glyphIdx] %><%
+		} else if (fontmap && fontmap[glyphs[glyphIdx]]) {
+			%>\<%= fontmap[glyphs[glyphIdx]] %><%
+		} else {
+			%>\<%= (61696+glyphIdx).toString(16) %><%
+		} %>";
 	}
 }<% } else { %>
 .<%= classPrefix %><%= glyphs[glyphIdx] %>:before {
-	content:"<% if (addLigatures) { %><%= glyphs[glyphIdx] %><% } else { %>\<%= (61696+glyphIdx).toString(16) %><% } %>";
+	content:"<% if (addLigatures) {
+		%><%= glyphs[glyphIdx] %><%
+	} else if (fontmap && fontmap[glyphs[glyphIdx]]) {
+		%>\<%= fontmap[glyphs[glyphIdx]] %><%
+	} else {
+		%>\<%= (61696+glyphIdx).toString(16) %><%
+	} %>";
 }<% } %>
 <% } } %>

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -101,6 +101,7 @@ module.exports = function(grunt) {
 		// Options
 		var o = {
 			fontBaseName: options.font || 'icons',
+			fontmap: options.fontmap || false,
 			destCss: params.destCss || params.dest,
 			dest: params.dest,
 			relativeFontPath: options.relativeFontPath,
@@ -180,12 +181,9 @@ module.exports = function(grunt) {
 				o.fontBaseName,
 				o.types.join(',')
 			];
-			if (o.addHashes) {
-				args.push('--hashes');
-			}
-			if (o.addLigatures) {
-				args.push('--ligatures');
-			}
+			if (o.fontmap) args.push('--fontmap='+o.fontmap);
+			if (o.addHashes) args.push('--hashes');
+			if (o.addLigatures) args.push('--ligatures');
 
 			grunt.util.spawn({
 				cmd: 'fontforge',
@@ -226,7 +224,7 @@ module.exports = function(grunt) {
 				try {
 					result = JSON.parse(json);
 				} catch (e) {
-					grunt.warn('Webfont did not receive a popper JSON result.\n' + e + '\n' + fontforgeProcess.stdout);
+					grunt.warn('Webfont did not receive a proper JSON result.\n' + e + '\n' + fontforgeProcess.stdout);
 				}
 
 				o.fontName = path.basename(result.file);
@@ -272,11 +270,20 @@ module.exports = function(grunt) {
 			// Now override values with templateOptions
 			if (o.templateOptions) o = _.extend(o, o.templateOptions);
 
+			// fontmap support
+			if (o.fontmap) {
+				var fontmap = {};
+				_.each(require(o.fontmap), function (value, name) {
+					fontmap[name] = value.charCodeAt(0).toString(16);
+				});
+			}
+
 			// Generate CSS
 			o.cssTemplate = readTemplate(o.template, o.syntax, '.css');
 			var cssFilePrefix = option(cssFilePrefixes, o.stylesheet);
 			var cssFile = path.join(o.destCss, cssFilePrefix + o.fontBaseName + '.' + o.stylesheet);
 			var cssContext = _.extend(o, {
+				fontmap: fontmap || false,
 				iconsStyles: true
 			});
 


### PR DESCRIPTION
This is by no means "elegant", or even tested, but it totes works. Just add the `fontmap` option to a webfont target's options object pointing to a .json file using the format:

``` json
{
  "filename.svg": "\uF001"
}
```
