### PR TITLE
Added glyphRename option 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -286,6 +286,24 @@ options: {
 }
 ```
 
+#### codepointFunction
+
+Type: `function` Default: `undefined`
+
+You can use this function to change the unicode-codepoints based on the filenames of the icons. By default the codepoints are generated as an autoincremented number.
+
+For example you can use the a trailing number in the svg-filename as unicode-codepoint so the existing codepoints dont change with added files.
+
+```js
+options: {
+  codepointFunction: function(name) {
+    var number = name.replace(/(.*)\/([0-9]+)(.*)(.svg)/g, "$2");
+    var codepoint = 0xE001 + parseInt(number);
+    return codepoint.toString(16);
+  }
+}
+```
+
 #### skip
 
 Type: `boolean` Default: `false`

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -56,9 +56,9 @@ module.exports = function(grunt) {
 			order: optionToArray(options.order, wf.fontFormats),
 			embed: options.embed === true ? ['woff'] : optionToArray(options.embed, false),
 			rename: options.rename || path.basename,
-			glyphRename: options.glyphRename,
 			engine: options.engine || 'fontforge',
 			codepoints: options.codepoints,
+			codepointFunction: options.codepointFunction,
 			ie7: options.ie7 || false
 		};
 
@@ -119,9 +119,9 @@ module.exports = function(grunt) {
 				return codepointsMap[name];
 			});
 		}
-		else if (o.glyphRename) {
+		else if (o.codepointFunction) {
 			o.codepoints = o.files.map(function(file) {
-				return o.glyphRename(file).replace(path.extname(file), '');
+				return o.codepointFunction(file).replace(path.extname(file), '');
 			});
 		}
 		else {


### PR DESCRIPTION
Currently the codepoints have to be added to the grunt configuration to avoid complete renumbering of the glyphs after adding new svg-files. It would be great to use a function for that too that uses the filename as input.
