### PR TITLE
Template not found error

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,15 +9,6 @@ module.exports = function(grunt) {
 
 	grunt.initConfig({
 		webfont: {
-
-      templateError: {
-        src: 'test/src/*.svg',
-        dest: 'test/tmp/template',
-        options: {
-          template: 'test/templates/template-adsf.css'
-        }
-      },
-
 			test1: {
 				src: 'test/src/*.svg',
 				dest: 'test/tmp/test1',

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -433,7 +433,7 @@ module.exports = function(grunt) {
 				return fs.readFileSync(filename, 'utf8');
 			}
 			else {
-				return false;
+				return grunt.fail.fatal('Cannot find template at path: ' + template);
 			}
 		}
 


### PR DESCRIPTION
I ran into a  `Fatal error: baseClass is not defined` message when trying to use a template file with the `webfont` task. It took me an embarrassing amount of time to realize that I configured the wrong path to my template file.

This pull request handles invalid template paths with a more descriptive `Fatal error: Cannot find template at path: not/a/path/to/template.css` message.

I attempted to test this behavior, but I couldn't figure out how to get nodeunit to catch the error thrown by `grunt.task.run`. So instead, I included a [commit](https://github.com/eschwartz/grunt-webfont/commit/9de515fc6467cf7373fb225c8e7dcc6f03265df0) which demonstrates the previous behavior.
