### PR TITLE
Warn on empty svgs list, carry on

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -32,6 +32,9 @@ module.exports = function(grunt) {
 		 * Winston to Grunt logger adapter.
 		 */
 		var logger = {
+			warn: function() {
+				grunt.logger.warn.apply(null, arguments);
+			},
 			error: function() {
 				grunt.warn.apply(null, arguments);
 			},
@@ -51,8 +54,7 @@ module.exports = function(grunt) {
 		// Source files
 		var files = _.filter(this.filesSrc, isSvgFile);
 		if (!files.length) {
-			logger.error('Specified empty list of source SVG files.');
-			return;
+			logger.warn('Specified empty list of source SVG files.');
 		}
 
 		// Options


### PR DESCRIPTION
In our build process, we generate several webfont configs to build fonts as needed for each of our compile targets. Some of these targets don't require any glyphs, and hence receive empty `src` lists.

Unfortunately, this causes the entire build to halt due to grunt-webfont treating this conditional as an error.

This PR retains the logging informing the user that no svgs were included, but allows the build to continue.

It also retains compatibility with Winston's logger, as Winston already includes a `warn` log level.
