### PR TITLE
Warn on empty svgs list, carry on

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
 		 */
 		var logger = {
 			warn: function() {
-				grunt.logger.warn.apply(null, arguments);
+				grunt.log.warn.apply(null, arguments);
 			},
 			error: function() {
 				grunt.warn.apply(null, arguments);


### PR DESCRIPTION
Fix for bug introduced in 4eefae5a85dcc4318791271caa18cbd8be5fc614

Should be `grunt.log.warn`, not `grunt.logger.warn`
