### PR TITLE
Continue async task processing on empty svgs list

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -55,6 +55,8 @@ module.exports = function(grunt) {
 		var files = _.filter(this.filesSrc, isSvgFile);
 		if (!files.length) {
 			logger.warn('Specified empty list of source SVG files.');
+			allDone();
+			return;
 		}
 
 		// Options


### PR DESCRIPTION
Continue async processing when list of glyphs is empty.
