### PR TITLE
Get CSS file extension from the template option if given.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,6 +75,22 @@ module.exports = function(grunt) {
 					template: 'test/templates/template.css'
 				}
 			},
+			template_scss: {
+				src: 'test/src/*.svg',
+				dest: 'test/tmp/template',
+				options: {
+					stylesheet: 'scss',
+					template: 'test/templates/template.scss'
+				}
+			},
+			template_sass: {
+				src: 'test/src/*.svg',
+				dest: 'test/tmp/template',
+				options: {
+					stylesheet: 'sass',
+					template: 'test/templates/template.sass'
+				}
+			},
 			html_template: {
 				src: 'test/src/*.svg',
 				dest: 'test/tmp/html_template',

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -18,6 +18,8 @@ module.exports = function(grunt) {
 	var _s = require('underscore.string');
 	var wf = require('./util/util');
 
+	var rFileExtension = /\.[^\\\/.]+$/;
+
 
 	grunt.registerMultiTask('webfont', 'Compile separate SVG files to webfont', function() {
 		['src', 'dest'].forEach(function(name) {
@@ -219,7 +221,16 @@ module.exports = function(grunt) {
 			if (o.templateOptions) o = _.extend(o, o.templateOptions);
 
 			// Generate CSS
-			o.cssTemplate = readTemplate(o.template, o.syntax, '.css');
+			// Use extension of o.template file if given, or default to .css
+			var ext = '.css';
+			var extMatches;
+			if (o.template) {
+				extMatches = o.template.match(rFileExtension);
+				if (extMatches && extMatches[0]) {
+					ext = extMatches[0];
+				}
+			}
+			o.cssTemplate = readTemplate(o.template, o.syntax, ext);
 			var cssFilePrefix = option(wf.cssFilePrefixes, o.stylesheet);
 			var cssFile = path.join(o.destCss, cssFilePrefix + o.fontBaseName + '.' + o.stylesheet);
 			var cssContext = _.extend(o, {
@@ -431,7 +442,7 @@ module.exports = function(grunt) {
 		 */
 		function readTemplate(template, syntax, ext, optional) {
 			var filename = template
-				? path.resolve(template.replace(/\.[^\\\/.]+$/, '') + ext)
+				? path.resolve(template.replace(rFileExtension, ext))
 				: path.join(__dirname, 'templates/' + syntax + ext)
 			;
 			if (fs.existsSync(filename)) {

--- a/test/templates/template.sass
+++ b/test/templates/template.sass
@@ -1,0 +1,19 @@
+/* Custom template */
+
+<% if (fontfaceStyles) { %>@font-face
+	font-family:"<%= fontBaseName %>"<% if (fontSrc1) { %>
+	src: <%= fontSrc1 %><% }%>
+	src: <%= fontSrc2 %>
+	font-weight:normal
+	font-style:normal
+<% } %>
+<% if (baseStyles) { %>.icon
+	font-family:"<%= fontBaseName %>"
+	display:inline-block
+	font-style:normal
+	speak:none
+	-webkit-font-smoothing:antialiased
+<% } %>
+<% if (iconsStyles) { %>/* Icons */<% for (var glyphIdx = 0; glyphIdx < glyphs.length; glyphIdx++) { %>
+.icon_<%= glyphs[glyphIdx] %>:before
+	content:"\<%= codepoints[glyphIdx] %>"<% } %><% } %>

--- a/test/templates/template.scss
+++ b/test/templates/template.scss
@@ -1,0 +1,20 @@
+/* Custom template */
+
+<% if (fontfaceStyles) { %>@font-face {
+	font-family:"<%= fontBaseName %>";<% if (fontSrc1) { %>
+	src: <%= fontSrc1 %>;<% }%>
+	src: <%= fontSrc2 %>;
+	font-weight:normal;
+	font-style:normal;
+	}
+<% } %>
+<% if (baseStyles) { %>.icon {
+	font-family:"<%= fontBaseName %>";
+	display:inline-block;
+	font-style:normal;
+	speak:none;
+	-webkit-font-smoothing:antialiased;
+	}
+<% } %>
+<% if (iconsStyles) { %>/* Icons */<% for (var glyphIdx = 0; glyphIdx < glyphs.length; glyphIdx++) { %>
+.icon_<%= glyphs[glyphIdx] %>:before { content:"\<%= codepoints[glyphIdx] %>"; }<% } %><% } %>


### PR DESCRIPTION
This allows the template file to have the correct extension if
it's not CSS.

Fix #173
