### PR TITLE
add 'round' option for fontforge engine

### DIFF
--- a/tasks/engines/fontforge/generate.py
+++ b/tasks/engines/fontforge/generate.py
@@ -68,10 +68,11 @@ for dirname, dirnames, filenames in os.walk(args['inputDir']):
 
 			if args['normalize']:
 				glyph.left_side_bearing = glyph.right_side_bearing = 0
-				glyph.round()
 			else:
 				glyph.width = args['fontHeight']
 
+			if args['round']:
+				glyph.round(int(args['round']))
 
 fontfile = args['dest'] + os.path.sep + args['fontBaseName']
 if args['addHashes']:

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -86,6 +86,7 @@ module.exports = function(grunt) {
 			startCodepoint: options.startCodepoint || wf.UNICODE_PUA_START,
 			ie7: options.ie7 === true,
 			normalize: options.normalize !== false,
+			round: options.round || false,
 			logger: logger,
 			fontHeight: options.fontHeight || 512,
 			descent: options.descent || 64,


### PR DESCRIPTION
As documented here
http://fontforge.org/python.html#cnt-round
round is useful to limit the output size of your fonts.

For example, to round to 2 decimal places, set `round: 100`.
To round to 1 decimal place, set `round: 10`.

Setting `round: true` will be interpreted as `round: 1` (0 decimal places).

I don't think rounding should be coupled to `normalize` either, so I uncoupled it.
