### PR TITLE
only clean generated font files when building, not all fonts

### DIFF
--- a/tasks/engines/fontforge.js
+++ b/tasks/engines/fontforge.js
@@ -98,7 +98,9 @@ module.exports = function(o, allDone) {
 	proc.stdin.end();
 
 	function generatedFontFiles() {
-		return glob.sync(path.join(o.dest, o.fontBaseName + wf.fontFileMask));
+		var types = _.intersection(wf.fontFormats.split(','), o.types);
+		var mask = wf.fontFileMask(types);
+		return glob.sync(path.join(o.dest, o.fontBaseName + mask));
 	}
 
 	function error() {

--- a/tasks/util/util.js
+++ b/tasks/util/util.js
@@ -81,7 +81,10 @@ exports.fontFormats = 'eot,woff,ttf,svg';
  * Glob mask for all available font formats.
  * @type {String}
  */
-exports.fontFileMask = '*.{' + exports.fontFormats + '}';
+exports.fontFileMask = function (fontFormats) {
+	fontFormats = fontFormats || exports.fontFormats;
+	return '*.{' + fontFormats + '}';
+}
 
 
 // Expose

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -478,7 +478,9 @@ module.exports = function(grunt) {
 		 * @return {Array}
 		 */
 		function generatedFontFiles() {
-			return glob.sync(path.join(o.dest, o.fontBaseName + wf.fontFileMask));
+			var types = _.intersection(wf.fontFormats.split(','), o.types);
+			var mask = wf.fontFileMask(types);
+			return glob.sync(path.join(o.dest, o.fontBaseName + mask));
 		}
 
 		/**


### PR DESCRIPTION
It is sometimes useful to run multiple grunt-webfont targets that output fonts to the same destination directory. However, currently grunt-webfont will delete all `fontName*.{eot,svg,ttf,woff}` files in the destination directory.
This patch makes it so that only the extensions specified in `options.types` will be removed from the destination folder before building the new fonts.
