### PR TITLE
Make task-level options as default options in target-level

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
 
 		var allDone = this.async();
 		var params = this.data;
-		var options = params.options || {};
+		var options = this.options();
 		var md5 = crypto.createHash('md5');
 
 		/**


### PR DESCRIPTION
Hi,
I'd like to use task-level options, but it didn't work, so changed the way of getting options variable.

http://gruntjs.com/api/inside-tasks#this.options

``` js
webfont: {
    options:{
        engine:'node'
    },
    production: {
        src: 'icons/*.svg',
        dest: 'build/fonts',
        options: {
            htmlDemo: 'false'
        }
    },
    demo: {
        src: 'icons/*.svg',
        dest: 'build/fonts',
        options: {
            htmlDemo: 'true'
        }
    }
}
```
