### PR TITLE
Stop running when regeneration is not needed

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -139,6 +139,7 @@ module.exports = function(grunt) {
 			if (!regenerationNeeded) {
 				logger.log('Font ' + chalk.cyan(o.fontName) + ' wasn’t changed since last run.');
 				completeTask();
+				return false;
 			}
 		}
 


### PR DESCRIPTION
When regeneration is not needed, the output less was removed.
This commit resolves this problem.