### PR TITLE
Fixed android 4.2.2 rendering issues

### DIFF
--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -27,7 +27,7 @@
 	speak:none;
 	text-decoration:inherit;
 	text-transform:none;
-	text-rendering:optimizeLegibility;
+	text-rendering:auto;
 	-webkit-font-smoothing:antialiased;
 	-moz-osx-font-smoothing:grayscale;
 }

--- a/tasks/templates/bootstrap.css
+++ b/tasks/templates/bootstrap.css
@@ -33,7 +33,7 @@
 	speak:none;
 	text-decoration:inherit;
 	text-transform:none;
-	text-rendering:optimizeLegibility;
+	text-rendering:auto;
 	-webkit-font-smoothing:antialiased;
 	-moz-osx-font-smoothing:grayscale;
 }<% } %>


### PR DESCRIPTION
The css rules `text-rendering:optimizeLegibility;` prevents the font being rendered in Android 4.2.2. Changing this to `text-rendering:auto;` solves it and was the accepted solution for font awesome. 

Please see https://github.com/FortAwesome/Font-Awesome/issues/1094 