### PR TITLE
Adds option to use custom filenames for generated font files.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -144,6 +144,20 @@ Type: `string` Default: `icons`
 
 Name of font and base name of font files.
 
+#### fontFilename
+
+Type: `string` Default: Same as `font` option
+
+Filename for generated font files, you can add placeholders for the same data that gets passed to the [template](#template).
+
+For example, to get the hash to be part of the filenames:
+
+```js
+options: {
+	fontFilename: 'icons-{hash}'
+}
+```
+
 #### hashes
 
 Type: `boolean` Default: `true`

--- a/tasks/engines/fontforge/generate.py
+++ b/tasks/engines/fontforge/generate.py
@@ -73,11 +73,11 @@ for dirname, dirnames, filenames in os.walk(args['inputDir']):
 			if args['round']:
 				glyph.round(int(args['round']))
 
-fontfile = args['dest'] + os.path.sep + args['fontBaseName']
+fontfile = args['dest'] + os.path.sep + args['fontFilename']
 
-f.fontname = args['fontBaseName']
-f.familyname = args['fontBaseName']
-f.fullname = args['fontBaseName']
+f.fontname = args['fontFilename']
+f.familyname = args['fontFilename']
+f.fullname = args['fontFilename']
 
 if args['addLigatures']:
 	def generate(filename):

--- a/tasks/util/util.js
+++ b/tasks/util/util.js
@@ -96,7 +96,7 @@ exports.fontFormats = 'eot,woff2,woff,ttf,svg';
  */
 exports.generatedFontFiles = function(o) {
  	var mask = '*.{' + o.types + '}';
-	return glob.sync(path.join(o.dest, o.fontBaseName + mask));
+	return glob.sync(path.join(o.dest, o.fontFilename + mask));
 };
 
 /**
@@ -107,7 +107,7 @@ exports.generatedFontFiles = function(o) {
  * @return {String}
  */
 exports.getFontPath = function(o, type) {
-	return path.join(o.dest, o.fontName + '.' + type);
+	return path.join(o.dest, o.fontFilename + '.' + type);
 };
 
 // Expose

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -105,6 +105,9 @@ module.exports = function(grunt) {
 			glyphs: []
 		});
 
+		o.hash = getHash();
+		o.fontFilename = template(options.fontFilename || o.fontBaseName, o);
+
 		// “Rename” files
 		o.glyphs = o.files.map(function(file) {
 			return o.rename(file).replace(path.extname(file), '');
@@ -123,7 +126,6 @@ module.exports = function(grunt) {
 		if (o.codepointsFile) saveCodepointsToFile();
 
 		// Check if we need to generate font
-		o.hash = getHash();
 		var previousHash = readHash(this.name, this.target);
 		logger.verbose('New hash:', o.hash, '- previous hash:', previousHash);
 		if (o.hash === previousHash) {
@@ -552,7 +554,7 @@ module.exports = function(grunt) {
 		 * @return {String}
 		 */
 		function generateFontSrc(type, font) {
-			var filename = template(o.fontName + font.ext, o);
+			var filename = template(o.fontFilename + font.ext, o);
 
 			var url;
 			if (font.embeddable && has(o.embed, type)) {


### PR DESCRIPTION
Adds a `fontFilename` option that allows generated font files to have custom filenames that don't necessarily need to match the generated font's name, this option also allows for appending a hash to the filename via `{hash}` syntax. The data that gets passed to `fontFilename` is the same data that gets passed to `template`.

For example: `fontFilename: 'icons-{hash}'`