### PR TITLE
fix codepointsFile

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -117,7 +117,6 @@ module.exports = function(grunt) {
 		// @todo Codepoint can be a Unicode code or character.
 		var currentCodepoint = o.startCodepoint;
 		if (!o.codepoints) o.codepoints = {};
-		if (o.codepointsFile) o.codepoints = readCodepointsFromFile();
 		o.glyphs.forEach(function(name) {
 			if (!o.codepoints[name]) {
 				o.codepoints[name] = getNextCodepoint();
@@ -357,24 +356,9 @@ module.exports = function(grunt) {
 		}
 
 		/**
-		 * Gets the codepoints from the set filepath in o.codepointsFile
-		 */
-		function readCodepointsFromFile(){
-			if (!o.codepointsFile) return {};
-			if (!fs.existsSync(o.codepointsFile)){
-				logger.verbose('Codepoints file not found');
-				return {};
-			}
-
-			var buffer = fs.readFileSync(o.codepointsFile);
-			return JSON.parse(buffer.toString());
-		}
-
-		/**
 		 * Saves the codespoints to the set file
 		 */
 		function saveCodepointsToFile(){
-			if (!o.codepointsFile) return;
 			var codepointsToString = JSON.stringify(o.codepoints);
 			fs.writeFile(o.codepointsFile, codepointsToString, function(err) {
 				if (err){


### PR DESCRIPTION
Outputting `codepointsFile` extend the last one. 
Then, It is not reflected, if SVG was removed.
I think that it is not necessary to read the last result.
thanks for reviewing.