### PR TITLE
Generate codepoints file json in a more human readable format.

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -370,7 +370,7 @@ module.exports = function(grunt) {
 		 */
 		function saveCodepointsToFile(){
 			if (!o.codepointsFile) return;
-			var codepointsToString = JSON.stringify(o.codepoints);
+			var codepointsToString = JSON.stringify(o.codepoints, null, 4);
 			fs.writeFile(o.codepointsFile, codepointsToString, function(err) {
 				if (err){
 					logger.error(err.message);


### PR DESCRIPTION
When using multiple or changing codepoints files, it is hard to diff the
file because the generated JSON is all on one line.  Proposing to simply call the overload of stringify to format it line by line and make it easier to read.  We could possibly just make this an option as well, but it didn't seem like a big deal to support backward compat on JSON formatting.