### PR TITLE
Changed codepoints file save to synchronous call

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -371,14 +371,12 @@ module.exports = function(grunt) {
 		function saveCodepointsToFile(){
 			if (!o.codepointsFile) return;
 			var codepointsToString = JSON.stringify(o.codepoints);
-			fs.writeFile(o.codepointsFile, codepointsToString, function(err) {
-				if (err){
-					logger.error(err.message);
-				}
-				else {
-					logger.verbose('Codepoints saved to file "'+ o.codepointsFile+'".');
-				}
-			});
+			try {
+				fs.writeFileSync(o.codepointsFile, codepointsToString);
+				logger.verbose('Codepoints saved to file "' + o.codepointsFile + '".');
+			} catch (err) {
+				logger.error(err.message);
+			}
 		}
 
 		/**


### PR DESCRIPTION
There is/was a strange file save occurrence where the defined
codepoints.json file was being written into a blank file.  Changing the
save to a sync file write seems to fix the symptom, so until I better
understand the problem this seems to best course of action.

This is in reference to: https://github.com/sapegin/grunt-webfont/issues/283

and the change was tested using @ajb's test repository https://github.com/ajb/grunt-webfont-283

The suggested change to the saveCodepointsToFile function:

```javascript
		/**
		 * Saves the codespoints to the set file
		 */
		function saveCodepointsToFile(){
			if (!o.codepointsFile) return;
			var codepointsToString = JSON.stringify(o.codepoints);
			try {
				fs.writeFileSync(o.codepointsFile, codepointsToString);
				logger.verbose('Codepoints saved to file "' + o.codepointsFile + '".');
			} catch (err) {
				logger.error(err.message);
			}
		}
```