### PR TITLE
-Updated optionsToArray to support a "trim" argument:

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -77,8 +77,8 @@ module.exports = function(grunt) {
 			htmlDemo: options.htmlDemo !== false,
 			htmlDemoTemplate: options.htmlDemoTemplate,
 			htmlDemoFilename: options.htmlDemoFilename,
-			styles: optionToArray(options.styles, 'font,icon', true),
-			types: optionToArray(options.types, 'eot,woff,ttf', true),
+			styles: optionToArray(options.styles, 'font,icon'),
+			types: optionToArray(options.types, 'eot,woff,ttf'),
 			order: optionToArray(options.order, wf.fontFormats),
 			embed: options.embed === true ? ['woff'] : optionToArray(options.embed, false),
 			rename: options.rename || path.basename,
@@ -434,23 +434,19 @@ module.exports = function(grunt) {
 		 */
 
 		/**
-		 * Convert a string of comma seperated words into an array
+		 * Convert a string of comma separated words into an array
 		 *
 		 * @param {String} val Input string
 		 * @param {String} defVal Default value
-		 * @param {Boolean} trim Whether or not to trim spaces off the ends of entries
 		 * @return {Array}
 		 */
-		function optionToArray(val, defVal, trim) {
+		function optionToArray(val, defVal) {
 			if (val === undefined) val = defVal;
 			if (!val) return [];
 			if (typeof val !== 'string') return val;
-			if (!!trim) {
-				return val.split(",").map(function(i) {
-					return i.trim();
-				});
-			}
-			return val.split(',');
+			return val.split(",").map(function(i) {
+				return i.trim();
+			});
 		}
 
 		/**

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -77,8 +77,8 @@ module.exports = function(grunt) {
 			htmlDemo: options.htmlDemo !== false,
 			htmlDemoTemplate: options.htmlDemoTemplate,
 			htmlDemoFilename: options.htmlDemoFilename,
-			styles: optionToArray(options.styles, 'font,icon'),
-			types: optionToArray(options.types, 'eot,woff,ttf'),
+			styles: optionToArray(options.styles, 'font,icon', true),
+			types: optionToArray(options.types, 'eot,woff,ttf', true),
 			order: optionToArray(options.order, wf.fontFormats),
 			embed: options.embed === true ? ['woff'] : optionToArray(options.embed, false),
 			rename: options.rename || path.basename,
@@ -438,18 +438,19 @@ module.exports = function(grunt) {
 		 *
 		 * @param {String} val Input string
 		 * @param {String} defVal Default value
+		 * @param {Boolean} trim Whether or not to trim spaces off the ends of entries
 		 * @return {Array}
 		 */
-		function optionToArray(val, defVal) {
+		function optionToArray(val, defVal, trim) {
 			if (val === undefined) val = defVal;
 			if (!val) return [];
 			if (typeof val !== 'string') return val;
-			if (val.indexOf(',') !== -1) {
-				return val.split(',');
+			if (!!trim) {
+				return val.split(",").map(function (i) {
+					return i.trim();
+				})
 			}
-			else {
-				return [val];
-			}
+			return val.split(',');
 		}
 
 		/**

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -446,7 +446,7 @@ module.exports = function(grunt) {
 			if (!val) return [];
 			if (typeof val !== 'string') return val;
 			if (!!trim) {
-				return val.split(",").map(function (i) {
+				return val.split(",").map(function(i) {
 					return i.trim();
 				});
 			}

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -448,7 +448,7 @@ module.exports = function(grunt) {
 			if (!!trim) {
 				return val.split(",").map(function (i) {
 					return i.trim();
-				})
+				});
 			}
 			return val.split(',');
 		}


### PR DESCRIPTION
@param {Boolean} trim Whether or not to trim spaces off the ends of entries
-According to my tests this has no effect on any other usages of the method since it returns the same output if the third argument is undefined (defaults to false).
-Enabled trim when setting both o.styles and o.types since they are comma-separated value lists that ideally would allow developers to use spaces without penalty. Not sure what other parameters would benefit from the trim functionality by default since I'm new to the plugin (asking for tribal knowledge on that one!)
-Removed check for index of "," in val, as it is unnecessary. val.split(",") will automatically return an array with val at [0] if val contains no commas.