### PR TITLE
fix option name for customOutput to match documentation

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
 			descent: options.descent !== undefined ? options.descent : 64,
 			cache: options.cache || path.join(__dirname, '..', '.cache'),
 			callback: options.callback,
-			customOutputs: options.customOutput
+			customOutputs: options.customOutputs
 		};
 
 		o = _.extend(o, {


### PR DESCRIPTION
tasks/webfont.js:107

it:
customOutputs: options.customOutput

should be:
customOutputs: options.customOutputs

to match documentation