### PR TITLE
remove `exec` and use native child_process.exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "async": "~1.5.0",
     "chalk": "~1.1.1",
-    "exec": "~0.2.1",
     "glob": "~6.0.1",
     "lodash": "~3.10.1",
     "memorystream": "~0.3.1",

--- a/tasks/engines/fontforge.js
+++ b/tasks/engines/fontforge.js
@@ -12,7 +12,7 @@ module.exports = function(o, allDone) {
 	var path = require('path');
 	var temp = require('temp');
 	var async = require('async');
-	var exec = require('exec');
+	var exec = require('child_process').exec;
 	var chalk = require('chalk');
 	var _ = require('lodash');
 	var logger = o.logger || require('winston');
@@ -29,10 +29,10 @@ module.exports = function(o, allDone) {
 		'fontforge',
 		'-script',
 		path.join(__dirname, 'fontforge/generate.py')
-	];
+	].join(' ');
 
 	var proc = exec(args, function(err, out, code) {
-		if (err instanceof Error && err.code === 'ENOENT') {
+		if (err instanceof Error && err.code === 127) {
 			return fontforgeNotFound();
 		}
 		else if (err) {

--- a/tasks/engines/node.js
+++ b/tasks/engines/node.js
@@ -12,7 +12,7 @@ module.exports = function(o, allDone) {
 	var path = require('path');
 	var async = require('async');
 	var temp = require('temp');
-	var exec = require('exec');
+	var exec = require('child_process').exec;
 	var _ = require('lodash');
 	var StringDecoder = require('string_decoder').StringDecoder;
 	var svgicons2svgfont = require('svgicons2svgfont');
@@ -174,19 +174,16 @@ module.exports = function(o, allDone) {
 			'--no-info',
 			originalFilepath,
 			hintedFilepath
-		];
+		].join(' ');
 
 		exec(args, function(err, out, code) {
 			if (err) {
-				if (err instanceof Error) {
-					if (err.code === 'ENOENT') {
-						logger.verbose('Hinting skipped, ttfautohint not found.');
-						done(false);
-						return;
-					}
-					err = err.message;
+				if (err.code === 127) {
+					logger.verbose('Hinting skipped, ttfautohint not found.');
+					done(false);
+					return;
 				}
-				logger.error('Can’t run ttfautohint.\n\n' + err);
+				logger.error('Can’t run ttfautohint.\n\n' + err.message);
 				done(false);
 				return;
 			}


### PR DESCRIPTION
`exec` npm module was deprecated. Replaced with standard nodeJS
`child_process.exec` method.

Fixes #282