### PR TITLE
No explicit mixing for LESS

### DIFF
--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -18,9 +18,9 @@
 <% } %>
 <% if (baseStyles) { %>.<%= baseClass %><% if (addLigatures) { %>,
 .ligature-icons<% } %> {
-	&:before {
+	<% if (stylesheet === 'less') { %>&:before {<% } %>
 		font-family:"<%= fontBaseName %>";
-	}
+	<% if (stylesheet === 'less') { %>}<% } %>
 	display:inline-block;
 	vertical-align:middle;
 	line-height:1;

--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -18,7 +18,9 @@
 <% } %>
 <% if (baseStyles) { %>.<%= baseClass %><% if (addLigatures) { %>,
 .ligature-icons<% } %> {
-	font-family:"<%= fontBaseName %>";
+	&:before {
+		font-family:"<%= fontBaseName %>";
+	}
 	display:inline-block;
 	vertical-align:middle;
 	line-height:1;

--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -35,17 +35,14 @@
 
 <% if (iconsStyles) { %>/* Icons */<% for (var glyphIdx = 0; glyphIdx < glyphs.length; glyphIdx++) { %>
 <% if (stylesheet === 'less') { %>
-.<%= mixinPrefix %><%= glyphs[glyphIdx] %>() {
+.<%= classPrefix %><%= glyphs[glyphIdx] %> {
 	&:before {
 		content:"<% if (addLigatures) { %><%= glyphs[glyphIdx] %><% } else { %>\<%= codepoints[glyphIdx] %><% } %>";
-	}
-	<% if (ie7) {%>
+	}<% if (ie7) {%>
 	*zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#x<%= codepoints[glyphIdx] %>;');
 	<% } %>
 }
-.<%= classPrefix %><%= glyphs[glyphIdx] %>{
- 	.<%= mixinPrefix %><%= glyphs[glyphIdx] %>();
-}<% } else { %>
+<% } else { %>
 <% if (ie7) {%>.<%= classPrefix %><%= glyphs[glyphIdx] %> {
 	*zoom: expression( this.runtimeStyle['zoom'] = '1', this.innerHTML = '&#x<%= codepoints[glyphIdx] %>;');
 }

--- a/test/webfont_test.js
+++ b/test/webfont_test.js
@@ -380,7 +380,7 @@ exports.webfont = {
 		svgs.forEach(function(file) {
 			var id = path.basename(file, '.svg');
 			test.ok(
-				find(less, '.icon-' + id + '() {\n\t&:before'),
+				find(less, '.icon_' + id + ' {\n\t&:before'),
 				'LESS Mixin ' + id + ' should be in CSS file.'
 			);
 		});
@@ -569,12 +569,12 @@ exports.webfont = {
 		// Every SVG file should have corresponding entry in LESS and HTML files
 		svgs.forEach(function(file) {
 			var id = path.basename(file, '.svg');
+			// test.ok(
+			// 		find(less, '.make-icon-' + id + ' {'),
+			// 		'Mixin .make-icon-' + id + ' should be in LESS file.'
+			// );
 			test.ok(
-					find(less, '.make-icon-' + id + '() {'),
-					'Mixin .make-icon-' + id + ' should be in LESS file.'
-			);
-			test.ok(
-					find(less, '.glyph_' + id + '{'),
+					find(less, '.glyph_' + id + ' {'),
 					'Icon .glyph_' + id + ' should be in LESS file.'
 			);
 			test.ok(
@@ -831,7 +831,7 @@ exports.webfont = {
 
 	target_overrides: function(test) {
 
-		var css = grunt.file.read('test/tmp/target_overrides_css/icons.css');		
+		var css = grunt.file.read('test/tmp/target_overrides_css/icons.css');
 		test.ok(fs.existsSync('test/tmp/target_overrides_css/icons.css') + ' file created.');
 
 		'woff,ttf,eot'.split(',').forEach(function(type) {


### PR DESCRIPTION
Addresses #309 

Additionally, I moved the font-family in the bem template to the `:before` pseudo element. Having it on the `.icon` element is unnecessary and tends to cause issues (the bootstrap template already has it like ehit).