### PR TITLE
execMaxBuffer option for setting child_process.exec() maxBuffer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -432,6 +432,9 @@ Each entry in `customOutputs` should be an object with the following parameters:
 
 At compile-time each template will have access to the same context as the compile-time environment of `htmlDemoTemplate` (as extended by the `context` object, if provided. See config-example below.
 
+#### execMaxBuffer
+ If you get stderr maxBuffer exceeded warning message, engine probably logged a lot of warning messages. To see this warnings run grunt in verbose mode `grunt --verbose`. To go over this warning you can try to increase buffer size by this option. Default value is `1024 * 200`
+
 ### Config Examples
 
 #### Simple font generation
@@ -623,6 +626,7 @@ Check the following...
 * Your paths are clockwise. Anti-clockwise paths may cause fills to occur differently.
 * Your paths are not overlapping. Overlapping paths will cause one of the areas to be inverted rather than combined. Use an editor to union your two paths together.
 * `autoHint` also adjusts the font file and can cause your font to look different to the SVG, so you could try switching it off (though it may make windows view of the font worse).
+* If you get stderr maxBuffer exceeded warning message, fontforge probably logged a lot of warning messages. To see this warnings run grunt in verbose mode `grunt --verbose`. To go over this warning you can try to increase buffer size by [execMaxBuffer](#execMaxBuffer).
 
 ## Changelog
 

--- a/tasks/engines/node.js
+++ b/tasks/engines/node.js
@@ -176,7 +176,7 @@ module.exports = function(o, allDone) {
 			hintedFilepath
 		].join(' ');
 
-		exec(args, function(err, out, code) {
+		exec(args, {maxBuffer: o.execMaxBuffer}, function(err, out, code) {
 			if (err) {
 				if (err.code === 127) {
 					logger.verbose('Hinting skipped, ttfautohint not found.');

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -104,7 +104,8 @@ module.exports = function(grunt) {
 			descent: options.descent !== undefined ? options.descent : 64,
 			cache: options.cache || path.join(__dirname, '..', '.cache'),
 			callback: options.callback,
-			customOutputs: options.customOutputs
+			customOutputs: options.customOutputs,
+			execMaxBuffer: options.execMaxBuffer || 1024 * 200 
 		};
 
 		o = _.extend(o, {

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -105,7 +105,7 @@ module.exports = function(grunt) {
 			cache: options.cache || path.join(__dirname, '..', '.cache'),
 			callback: options.callback,
 			customOutputs: options.customOutputs,
-			execMaxBuffer: options.execMaxBuffer || 1024 * 200 
+			execMaxBuffer: options.execMaxBuffer || 1024 * 200
 		};
 
 		o = _.extend(o, {


### PR DESCRIPTION
#319 If engine log a lot of messages to stdout or stderr, the child process is killed. You can increase buffer size by this option.

If you run grunt --verbose, output of fontforge will by logged by logger.

This changes has been made because fontforge produces warning messages if svg format is not fully valid and buffer of stderr can exceed and you should have some way to show these warnings.