### PR TITLE
fixed fatal error in node v6 passing `undefined` to path.extname()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -189,7 +189,7 @@ Icon classes syntax. `bem` for double class names: `icon icon_awesome` or `boots
 
 #### template
 
-Type: `string` Default: `null`
+Type: `string` Default: ``
 
 Custom CSS template path (see `tasks/templates` for some examples). Should be used instead of `syntax`. (You probably need to define `htmlDemoTemplate` option too.)
 

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -71,6 +71,11 @@ module.exports = function(grunt) {
 			return;
 		}
 
+		// path must be a string, see https://nodejs.org/api/path.html#path_path_extname_path
+		if (typeof options.template !== 'string') {
+			options.template = '';
+		}
+
 		// Options
 		var o = {
 			logger: logger,


### PR DESCRIPTION
Due to changes in the last version of node passing `null` or `undefined` to path.extname() is not allowed anymore and will lead to `Fatal error: Path must be a string. Received undefined`
see https://nodejs.org/api/path.html#path_path_extname_path