### PR TITLE
Add version option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -270,6 +270,12 @@ Type: `string` Default: `null`
 
 Custom font path. Will be used instead of `destCss` *in* CSS file. Useful with CSS preprocessors.
 
+#### version
+
+Type: `string` Default: `false`
+
+Version number added to `.ttf` version of the font (FontForge Engine only). Also be used in the heading of the default demo.html template. Useful to align with the version of other assets that are part of a larger system.
+
 #### htmlDemo
 
 Type: `boolean` Default: `true`

--- a/Readme.md
+++ b/Readme.md
@@ -274,7 +274,7 @@ Custom font path. Will be used instead of `destCss` *in* CSS file. Useful with C
 
 Type: `string` Default: `false`
 
-Version number added to `.ttf` version of the font (FontForge Engine only). Also be used in the heading of the default demo.html template. Useful to align with the version of other assets that are part of a larger system.
+Version number added to `.ttf` version of the font (FontForge Engine only). Also used in the heading of the default demo.html template. Useful to align with the version of other assets that are part of a larger system.
 
 #### htmlDemo
 

--- a/tasks/engines/fontforge/generate.py
+++ b/tasks/engines/fontforge/generate.py
@@ -16,6 +16,8 @@ f.design_size = 16
 f.em = args['fontHeight']
 f.descent = args['descent']
 f.ascent = args['fontHeight'] - args['descent']
+if args['version']:
+	f.version = args['version']
 if args['normalize']:
 	f.autoWidth(0, 0, args['fontHeight'])
 

--- a/tasks/templates/demo.html
+++ b/tasks/templates/demo.html
@@ -18,6 +18,10 @@
 			font-size:32px;
 			font-weight:normal;
 			}
+		h1 small {
+			font-size: 0.8em;
+			padding-left: 2em;
+		}
 		.icons {
 			margin-bottom:40px;
 			-webkit-column-count:5;
@@ -55,7 +59,7 @@
 		</style>
 	</head>
 	<body>
-		<h1><%= fontBaseName %></h1>
+		<h1><%= fontBaseName %><% if (version) { %><small>version <%= version %></small><% } %></h1>
 
 		<div class="icons" id="icons">
 			<% for (var glyphIdx = 0; glyphIdx < glyphs.length; glyphIdx++) { var glyph = glyphs[glyphIdx] %>

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -108,6 +108,7 @@ module.exports = function(grunt) {
 			round: options.round !== undefined ? options.round : 10e12,
 			fontHeight: options.fontHeight !== undefined ? options.fontHeight : 512,
 			descent: options.descent !== undefined ? options.descent : 64,
+			version: options.version !== undefined ? options.version : false,
 			cache: options.cache || path.join(__dirname, '..', '.cache'),
 			callback: options.callback,
 			customOutputs: options.customOutputs,


### PR DESCRIPTION
Outputs as part of .ttf file metadata (fontforge engine only) and also displays in demo html heading.

Looked into adding to the node engine, but it looks like svg2ttf would need to be updated to accept it as an input.

All tests pass for me locally.