### PR TITLE
Always pass glyph name to createChar()

### DIFF
--- a/tasks/engines/fontforge/generate.py
+++ b/tasks/engines/fontforge/generate.py
@@ -64,7 +64,7 @@ for dirname, dirnames, filenames in os.walk(args['inputDir']):
 				glyph = f.createChar(cp, name)
 				glyph.addPosSub('liga', tuple(name))
 			else:
-				glyph = f.createChar(cp)
+				glyph = f.createChar(cp, str(name))
 			glyph.importOutlines(filePath)
 
 			if args['normalize']:


### PR DESCRIPTION
In order to create unencoded glyphs (by specifying their codepoint as -1), it's necessary to pass a name to createChar. This is useful for glyphs that should not appear in the cmap, but will be accessed by OpenType features created later, separately from the grunt-webfont task.