### PR TITLE
Allow unique fontFamilyName

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -303,6 +303,14 @@ module.exports = function(grunt) {
 					destCss: 'test/tmp/target_overrides_css',
 				}
 			},
+			font_family_name: {
+				src: 'test/src/*.svg',
+				dest: 'test/tmp/font_family_name',
+				options: {
+					fontFamilyName: 'customName',
+					types: 'ttf',
+				}
+			},
 			custom_output: {
 				src: 'test/src/*.svg',
 				options: {

--- a/Readme.md
+++ b/Readme.md
@@ -410,6 +410,18 @@ Type: `number` Default: `512`
 
 The output font height.
 
+#### fontFamilyName
+
+Type: `string` Default: _`font` value_
+
+If you’d like your generated fonts to have a name that’s different than the `font` value, you can specify this as a string. This will allow a unique display name within design authoring tools when installing fonts locally. For example, your font’s name could be `GitHub Octicons` with a filename of `octicons.ttf`.
+
+```javascript
+options: {
+	fontFamilyName: 'GitHub Octicons',
+}
+```
+
 #### descent
 
 Type: `number` Default: `64`

--- a/tasks/engines/fontforge/generate.py
+++ b/tasks/engines/fontforge/generate.py
@@ -78,8 +78,8 @@ for dirname, dirnames, filenames in os.walk(args['inputDir']):
 fontfile = args['dest'] + os.path.sep + args['fontFilename']
 
 f.fontname = args['fontFilename']
-f.familyname = args['fontFilename']
-f.fullname = args['fontFilename']
+f.familyname = args['fontFamilyName']
+f.fullname = args['fontFamilyName']
 
 if args['addLigatures']:
 	def generate(filename):

--- a/tasks/engines/node.js
+++ b/tasks/engines/node.js
@@ -34,7 +34,7 @@ module.exports = function(o, allDone) {
 			var decoder = new StringDecoder('utf8');
 			svgFilesToStreams(o.files, function(streams) {
 				var stream = svgicons2svgfont(streams, {
-					fontName: o.fontName,
+					fontName: o.fontFamilyName,
 					fontHeight: o.fontHeight,
 					descent: o.descent,
 					normalize: o.normalize,

--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -3,13 +3,13 @@
 <% if (fontfaceStyles) { %>
 <% if (fontSrc1 && embed.length) { %>
 @font-face {
-	font-family:"<%= fontBaseName %>";
+	font-family:"<%= fontFamilyName %>";
 	src:<%= fontSrc1 %>;
 	font-weight:normal;
 	font-style:normal;
 }
 <% } %>@font-face {
-	font-family:"<%= fontBaseName %>";<% if (fontSrc1) { %>
+	font-family:"<%= fontFamilyName %>";<% if (fontSrc1) { %>
 	src:<%= fontSrc1 %>;<% }%>
 	src:<%= fontSrc2 %>;
 	font-weight:normal;
@@ -19,7 +19,7 @@
 <% if (baseStyles) { %>.<%= baseClass %><% if (addLigatures) { %>,
 .ligature-icons<% } %> {
 	<% if (stylesheet === 'less') { %>&:before {<% } %>
-		font-family:"<%= fontBaseName %>";
+		font-family:"<%= fontFamilyName %>";
 	<% if (stylesheet === 'less') { %>}<% } %>
 	display:inline-block;
 	vertical-align:middle;

--- a/tasks/templates/bootstrap.css
+++ b/tasks/templates/bootstrap.css
@@ -4,13 +4,13 @@
 <% if (fontfaceStyles) { %>
 <% if (fontSrc1 && embed.length) { %>
 @font-face {
-    font-family:"<%= fontBaseName %>";
+    font-family:"<%= fontFamilyName %>";
     src:<%= fontSrc1 %>;
     font-weight:normal;
     font-style:normal;
 }
 <% } %>@font-face {
-	font-family:"<%= fontBaseName %>";<% if (fontSrc1) { %>
+	font-family:"<%= fontFamilyName %>";<% if (fontSrc1) { %>
 	src:<%= fontSrc1 %>;<% }%>
 	src:<%= fontSrc2 %>;
 	font-weight:normal;
@@ -24,7 +24,7 @@
 [class^="<%= classPrefix %>"],
 [class*=" <%= classPrefix %>"]<% } %><% if (addLigatures) { %>,
 .ligature-icons<% } %> {
-	font-family:"<%= fontBaseName %>";
+	font-family:"<%= fontFamilyName %>";
 	display:inline-block;
 	vertical-align:middle;
 	line-height:1;
@@ -42,7 +42,7 @@
 <% for (var glyphIdx = 0; glyphIdx < glyphs.length; glyphIdx++) { %>
 .<%= classPrefix %><%= glyphs[glyphIdx] %><% if(glyphIdx === glyphs.length-1) { %> { <% } else { %>, <% } } %>
 	&:before {
-		font-family:"<%= fontBaseName %>";
+		font-family:"<%= fontFamilyName %>";
 		display:inline-block;
 		font-weight:normal;
 		font-style:normal;

--- a/tasks/templates/demo.html
+++ b/tasks/templates/demo.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<meta charset="utf-8">
-		<title><%= fontBaseName %></title>
+		<title><%= fontFamilyName %></title>
 		<style>
 		body {
 			margin:0;
@@ -59,7 +59,7 @@
 		</style>
 	</head>
 	<body>
-		<h1><%= fontBaseName %><% if (version) { %><small>version <%= version %></small><% } %></h1>
+		<h1><%= fontFamilyName %><% if (version) { %><small>version <%= version %></small><% } %></h1>
 
 		<div class="icons" id="icons">
 			<% for (var glyphIdx = 0; glyphIdx < glyphs.length; glyphIdx++) { var glyph = glyphs[glyphIdx] %>

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -80,7 +80,6 @@ module.exports = function(grunt) {
 		var o = {
 			logger: logger,
 			fontBaseName: options.font || 'icons',
-			fontFamilyName: options.fontFamilyName || options.font,
 			destCss: options.destCss || params.destCss || params.dest,
 			dest: options.dest || params.dest,
 			relativeFontPath: options.relativeFontPath,
@@ -129,6 +128,7 @@ module.exports = function(grunt) {
 
 		o.hash = getHash();
 		o.fontFilename = template(options.fontFilename || o.fontBaseName, o);
+		o.fontFamilyName = template(options.fontFamilyName || o.fontBaseName, o);
 
 		// “Rename” files
 		o.glyphs = o.files.map(function(file) {

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -80,6 +80,7 @@ module.exports = function(grunt) {
 		var o = {
 			logger: logger,
 			fontBaseName: options.font || 'icons',
+			fontFamilyName: options.fontFamilyName || options.font,
 			destCss: options.destCss || params.destCss || params.dest,
 			dest: options.dest || params.dest,
 			relativeFontPath: options.relativeFontPath,

--- a/test/webfont_test.js
+++ b/test/webfont_test.js
@@ -677,7 +677,7 @@ exports.webfont = {
 		test.done();
 	},
 
-	optimize_disbaled: function(test){
+	optimize_disabled: function(test){
 		var optimizedPathSegment = '280.2V280.098C349.867 293.072 358.595';
 		var svg	= grunt.file.read('test/tmp/optimize_disabled/icons.svg');
 	 	if(svg.indexOf(optimizedPathSegment) > -1) {

--- a/test/webfont_test.js
+++ b/test/webfont_test.js
@@ -861,6 +861,21 @@ exports.webfont = {
 		test.done();
 	},
 
+	font_family_name: function(test) {
+		var html = grunt.file.read('test/tmp/font_family_name/icons.html');
+
+		// fontFamilyName should be in the HTML file's title
+		test.ok(
+			find(html, '<title>customName</title>'),
+			'fontFamilyName should be in the HTML file title'
+		);
+
+		// File should still have default name if only fontFamilyName is specified
+		test.ok(fs.existsSync('test/tmp/font_family_name/icons.ttf'));
+
+		test.done();
+	},
+
 	custom_outputs: function(test) {
 
 		// File should have been created when filename is specified


### PR DESCRIPTION
This pull request allows you to specify a unique fontFamilyName that's independent of the filename.

We ran into wanting this over at https://github.com/primer/octicons/pull/91

`fontFamilyName` should just fall back to `font` so it shouldn't break anything if `fontFamilyName` isn't set in the options.

Am I missing anything?