### PR TITLE
Make sure the htmlRelativeFontPath is correct

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -417,7 +417,7 @@ module.exports = function(grunt) {
 
 			// Prepare relative font paths for injection into @font-face refs in HTML
 			var relativeRe = new RegExp(_s.escapeRegExp(o.relativeFontPath), 'g');
-			var htmlRelativeFontPath = normalizePath(path.relative(o.destHtml, o.relativeFontPath));
+			var htmlRelativeFontPath = normalizePath(path.relative(o.destHtml, o.dest));
 			var _fontSrc1 = o.fontSrc1.replace(relativeRe, htmlRelativeFontPath);
 			var _fontSrc2 = o.fontSrc2.replace(relativeRe, htmlRelativeFontPath);
 


### PR DESCRIPTION
The _htmlRelativeFontPath_ should be the relative path from _estHtml_ to _o.dest_, instead of be the relative path from _destHtml_ to another relative path.

So I just change one line. And this change will fix the bugs: 
1. [relativeRe generates zero width matches in destHtml](https://github.com/sapegin/grunt-webfont/issues/237)
2. If we set _destCss_ or _destHtml_ in task, the src path of the font-face in html will not be correct.

BTW, I am sorry I don't understand your test cases so I didn't add new test for my change.