### PR TITLE
[BUGFIX] Set correct scss variable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -635,7 +635,7 @@ You can enable the `fontPathVariables` in combination with `relativeFontPath` to
 
 For example scss:
 ```scss
-$icons-font-path= "/relativeFontPath/" !default;
+$icons-font-path : "/relativeFontPath/" !default;
 @font-face {
 	font-family:"icons";
 	src:url($icons-font-path + "icons.eot");

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -696,11 +696,11 @@ module.exports = function(grunt) {
 				if (o.fontPathVariables &&  stylesheet !== 'css') {
 					if (stylesheet === 'less') {
 						fontPathVariableName = '@' + fontPathVariableName;
-						o.fontPathVariable = fontPathVariableName + ': "' + o.relativeFontPath + '";';
+						o.fontPathVariable = fontPathVariableName + ' : "' + o.relativeFontPath + '";';
 					}
 					else {
 						fontPathVariableName = '$' + fontPathVariableName;
-						o.fontPathVariable = fontPathVariableName + '= "' + o.relativeFontPath + '" !default;';
+						o.fontPathVariable = fontPathVariableName + ' : "' + o.relativeFontPath + '" !default;';
 					}
 					url = filename;
 				}

--- a/test/webfont_test.js
+++ b/test/webfont_test.js
@@ -314,7 +314,7 @@ exports.webfont = {
 
 		// There should be a variable declaration for scss preprocessor
 		test.ok(
-			find(css, '$icons-font-path= "../iamrelative/" !default;'),
+			find(css, '$icons-font-path : "../iamrelative/" !default;'),
 			'SCSS enable template variables: variable exists.'
 		);
 


### PR DESCRIPTION
Bugfix for yesterday commit -_- It was too late... @sapegin

Set sass var `$variable: XXXX !default;` instead of `$variable= XXXX !default;`

```
Module build failed: 
$icons-font-path = "/build/fonts/" !default;
^
      Expected ':' after $icons-font-path in assignment statement
```
