### PR TITLE
[BUGFIX] Remove vertical-align css override (#235)

### DIFF
--- a/tasks/templates/bem.css
+++ b/tasks/templates/bem.css
@@ -25,7 +25,6 @@
 		font-family:"<%= fontFamilyName %>";
 	<% if (stylesheet === 'less') { %>}<% } %>
 	display:inline-block;
-	vertical-align:middle;
 	line-height:1;
 	font-weight:normal;
 	font-style:normal;

--- a/tasks/templates/bootstrap.css
+++ b/tasks/templates/bootstrap.css
@@ -29,7 +29,6 @@
 .ligature-icons<% } %> {
 	font-family:"<%= fontFamilyName %>";
 	display:inline-block;
-	vertical-align:middle;
 	line-height:1;
 	font-weight:normal;
 	font-style:normal;


### PR DESCRIPTION
See: https://github.com/sapegin/grunt-webfont/issues/235 @sapegin 