### PR TITLE
[BUGFIX] Add cachebuster hash to iefix eot #343

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -714,6 +714,9 @@ module.exports = function(grunt) {
 						// Put hash at the end of an URL or before #hash
 						url = url.replace(/(#|$)/, '?' + o.hash + '$1');
 					}
+					else {
+						url = url.replace(/(#|$)/, o.hash + '$1');
+					}
 				}
 			}
 


### PR DESCRIPTION
This patch adds the cache busting hash to the #iefix eot font. I couldn't find any reason not to.

Example: 
`src:url("omropicons.eot?#iefix") format("embedded-opentype"),`

becomes

`src:url("omropicons.eot?fa94893df8ce9f498319f56d3b45332c#iefix") format("embedded-opentype"),`