### PR TITLE
Add ligature support to Node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "memorystream": "~0.3.1",
     "mkdirp": "~0.5.1",
     "svg2ttf": "~2.1.1",
-    "svgicons2svgfont": "~1.1.0",
+    "svgicons2svgfont": "~8.0.0",
     "svgo": "~0.6.1",
     "temp": "~0.8.3",
     "ttf2eot": "~1.3.0",

--- a/tasks/engines/node.js
+++ b/tasks/engines/node.js
@@ -15,7 +15,7 @@ module.exports = function(o, allDone) {
 	var exec = require('child_process').exec;
 	var _ = require('lodash');
 	var StringDecoder = require('string_decoder').StringDecoder;
-	var svgicons2svgfont = require('svgicons2svgfont');
+	var SVGIcons2SVGFontStream = require('svgicons2svgfont');
 	var svg2ttf = require('svg2ttf');
 	var ttf2woff = require('ttf2woff');
 	var ttf2eot = require('ttf2eot');
@@ -33,7 +33,7 @@ module.exports = function(o, allDone) {
 			var font = '';
 			var decoder = new StringDecoder('utf8');
 			svgFilesToStreams(o.files, function(streams) {
-				var stream = svgicons2svgfont(streams, {
+				var stream = new SVGIcons2SVGFontStream({
 					fontName: o.fontFamilyName,
 					fontHeight: o.fontHeight,
 					descent: o.descent,
@@ -44,11 +44,16 @@ module.exports = function(o, allDone) {
 				});
 				stream.on('data', function(chunk) {
 					font += decoder.write(chunk);
-				});
-				stream.on('end', function() {
+				}).on('finish',function() {
 					fonts.svg = font;
 					done(font);
 				});
+
+
+				streams.forEach(function(glyph) {
+					stream.write(glyph);
+				});
+				stream.end();
 			});
 		},
 
@@ -126,11 +131,14 @@ module.exports = function(o, allDone) {
 		async.map(files, function(file, fileDone) {
 
 			function fileStreamed(name, stream) {
-				fileDone(null, {
-					codepoint: o.codepoints[name],
-					name: name,
-					stream: stream
-				});
+				stream.metadata = {
+					unicode: [String.fromCodePoint(o.codepoints[name])],
+					name: name
+				};
+				if (o.addLigatures) {
+					stream.metadata.unicode.push(name);
+				}
+				fileDone(null, stream);
 			}
 
 			function streamSVG(name, file) {


### PR DESCRIPTION
Although `svgicons2svgfont` added support for ligatures several versions ago, `grunt-webfont` still depends on v1.1.0 (see #251) - so the Node engine is unable to support ligatures.  This PR updates to the current (at time of writing) version - v8.0.0 - and passes through the relevant metadata to generate ligatures (if the `ligatures` option is enabled).

I haven't updated the readme in this PR; if you'd like me to include such an update, please let me know what version number you'd release this change in (so that I can list ligatures as supported in the Node engine from that version onwards).

Closes #251