### PR TITLE
Add `ligaturesOnly` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "memorystream": "~0.3.1",
     "mkdirp": "~0.5.1",
     "svg2ttf": "~2.1.1",
-    "svgicons2svgfont": "~1.1.0",
+    "svgicons2svgfont": "~8.0.0",
     "svgo": "~0.6.1",
     "temp": "~0.8.3",
     "ttf2eot": "~1.3.0",

--- a/tasks/engines/node.js
+++ b/tasks/engines/node.js
@@ -15,7 +15,7 @@ module.exports = function(o, allDone) {
 	var exec = require('child_process').exec;
 	var _ = require('lodash');
 	var StringDecoder = require('string_decoder').StringDecoder;
-	var svgicons2svgfont = require('svgicons2svgfont');
+	var SVGIcons2SVGFontStream = require('svgicons2svgfont');
 	var svg2ttf = require('svg2ttf');
 	var ttf2woff = require('ttf2woff');
 	var ttf2eot = require('ttf2eot');
@@ -33,7 +33,7 @@ module.exports = function(o, allDone) {
 			var font = '';
 			var decoder = new StringDecoder('utf8');
 			svgFilesToStreams(o.files, function(streams) {
-				var stream = svgicons2svgfont(streams, {
+				var stream = new SVGIcons2SVGFontStream({
 					fontName: o.fontFamilyName,
 					fontHeight: o.fontHeight,
 					descent: o.descent,
@@ -44,11 +44,16 @@ module.exports = function(o, allDone) {
 				});
 				stream.on('data', function(chunk) {
 					font += decoder.write(chunk);
-				});
-				stream.on('end', function() {
+				}).on('finish',function() {
 					fonts.svg = font;
 					done(font);
 				});
+
+
+				streams.forEach(function(glyph) {
+					stream.write(glyph);
+				});
+				stream.end();
 			});
 		},
 
@@ -126,11 +131,14 @@ module.exports = function(o, allDone) {
 		async.map(files, function(file, fileDone) {
 
 			function fileStreamed(name, stream) {
-				fileDone(null, {
-					codepoint: o.codepoints[name],
-					name: name,
-					stream: stream
-				});
+				stream.metadata = {
+					unicode: [String.fromCodePoint(o.codepoints[name])],
+					name: name
+				};
+				if (o.addLigatures) {
+					stream.metadata.unicode.push(name);
+				}
+				fileDone(null, stream);
 			}
 
 			function streamSVG(name, file) {

--- a/tasks/engines/node.js
+++ b/tasks/engines/node.js
@@ -135,7 +135,9 @@ module.exports = function(o, allDone) {
 					unicode: [String.fromCodePoint(o.codepoints[name])],
 					name: name
 				};
-				if (o.addLigatures) {
+				if (o.ligaturesOnly) {
+					stream.metadata.unicode = [name];
+				} else if (o.addLigatures) {
 					stream.metadata.unicode.push(name);
 				}
 				fileDone(null, stream);

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -90,6 +90,7 @@ module.exports = function(grunt) {
 			fontPathVariables: options.fontPathVariables || false,
 			addHashes: options.hashes !== false,
 			addLigatures: options.ligatures === true,
+			ligaturesOnly: options.ligaturesOnly === true,
 			template: options.template,
 			syntax: options.syntax || 'bem',
 			templateOptions: options.templateOptions || {},


### PR DESCRIPTION
Builds on #376 by introducing a new `ligaturesOnly` option which removes the regular glyphs, so that the generated files are similar to those of a non-ligature font.  (The `ligatures` option results in an approximate doubling of output file sizes, as glyphs are repeated.)