### PR TITLE
Ensure no parameter is passed to 'done' function

### DIFF
--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -318,7 +318,7 @@ module.exports = function(grunt) {
 
 			// Save
 			var woff2FontPath = wf.getFontPath(o, 'woff2');
-			fs.writeFile(woff2FontPath, woffFont, done);
+			fs.writeFile(woff2FontPath, woffFont, function() {done();});
 		}
 
 		/**


### PR DESCRIPTION
Since nodejs 9.0.0, fs.writeFile seems to throw an undefined parameter as error instead of no parameter in the call back. It leads to an error 'done is not a function'

Now working with node 10.0.0