### PR TITLE
Update all dependencies to latest versions

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -29,10 +29,5 @@
 	"maximumLineLength": 140,
 	"safeContextKeyword": "that",
 	"requireDotNotation": true,
-	"validateJSDoc": {
-		"checkParamNames": true,
-		"checkRedundantParams": true,
-		"requireParamTypes": true
-	},
 	"excludeFiles": ["node_modules/**"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.12"
-  - "4"
-  - "5"
-  - "6"
+  - "10"
+  - "12"
 addons:
   apt:
     packages:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-webfont",
   "description": "Ultimate SVG to webfont converter for Grunt.",
-  "version": "1.7.2",
+  "version": "2.0.0",
   "homepage": "https://github.com/sapegin/grunt-webfont",
   "author": {
     "name": "Artem Sapegin",
@@ -10,7 +10,8 @@
   "contributors": [
     "Maxime Thirouin (http://moox.io/)",
     "Aaron Lampros (https://github.com/alampros)",
-    "Cyrille Meichel (https://github.com/landru29)"
+    "Cyrille Meichel (https://github.com/landru29)",
+    "Justin Leider (https://github.com/jleider)"
   ],
   "repository": {
     "type": "git",
@@ -25,39 +26,39 @@
     "test": "grunt --stack"
   },
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
-    "async": "~1.5.2",
-    "chalk": "~1.1.1",
-    "glob": "~7.0.0",
+    "async": "~3.1.0",
+    "chalk": "~3.0.0",
+    "glob": "~7.1.6",
     "lodash": "~4.17.10",
     "memorystream": "~0.3.1",
     "mkdirp": "~0.5.1",
-    "svg2ttf": "~2.1.1",
-    "svgicons2svgfont": "~1.1.0",
-    "svgo": "~0.6.1",
-    "temp": "~0.8.3",
-    "ttf2eot": "~1.3.0",
-    "ttf2woff": "~1.3.0",
-    "ttf2woff2": "~2.0.3",
-    "underscore.string": "~3.2.3",
-    "winston": "~2.1.1"
+    "svg2ttf": "~4.3.0",
+    "svgicons2svgfont": "~9.1.1",
+    "svgo": "~1.3.2",
+    "temp": "~0.9.1",
+    "ttf2eot": "~2.0.0",
+    "ttf2woff": "~2.0.1",
+    "ttf2woff2": "~3.0.0",
+    "underscore.string": "~3.3.5",
+    "winston": "~3.2.1"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-cli": "~0.1.13",
-    "grunt-contrib-clean": "~1.0.0",
-    "grunt-contrib-jshint": "~0.11.3",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-jscs": "~1.0.0",
-    "load-grunt-tasks": "~3.4.0",
-    "stylus": "~0.53.0",
+    "grunt": "~1.0.4",
+    "grunt-cli": "~1.3.2",
+    "grunt-contrib-clean": "~2.0.0",
+    "grunt-contrib-jshint": "~2.1.0",
+    "grunt-contrib-nodeunit": "~2.0.0",
+    "grunt-contrib-watch": "~1.1.0",
+    "grunt-jscs": "~3.0.1",
+    "load-grunt-tasks": "~5.1.0",
+    "stylus": "~0.54.7",
     "xml2js": "~0.4.16"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": ">=1.0.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/bin/eotlitetool.py
+++ b/tasks/bin/eotlitetool.py
@@ -373,7 +373,7 @@ def make_eot_name_headers(fontdata, nameTableDir):
         else:
             nameheaders.append(struct.pack('4x'))  # len = 0, padding = 0
 
-    return ''.join(nameheaders)
+    return b''.join(nameheaders)
 
 # just return a null-string (len = 0)
 def make_root_string():
@@ -445,11 +445,11 @@ def make_eot_header(fontdata):
                         *([eotSize, fontDataSize, version, flags] + panose + [charset, italic] +
                           [weight, fsType, magicNumber] + urange + codepage + [checkSumAdjustment]))
 
-    return ''.join((fixed, nameheaders, rootstring))
+    return b''.join((fixed, nameheaders, rootstring))
 
 
 def write_eot_font(eot, header, data):
-    open(eot,'wb').write(''.join((header, data)))
+    open(eot,'wb').write(b''.join((header, data)))
     return
 
 def main():

--- a/tasks/webfont.js
+++ b/tasks/webfont.js
@@ -54,8 +54,8 @@ module.exports = function(grunt) {
 		 * Check for `dest` param on either target config or global options object
 		 */
 		if (_.isUndefined(params.dest) && _.isUndefined(options.dest)) {
-			logger.warn('Required property ' + [this.name, this.target, 'dest'].join('.')
-				+ ' or ' + [this.name, this.target, 'options.dest'].join('.') + ' missing.');
+			logger.warn('Required property ' + [this.name, this.target, 'dest'].join('.') +
+				' or ' + [this.name, this.target, 'options.dest'].join('.') + ' missing.');
 		}
 
 		if (options.skip) {


### PR DESCRIPTION
- Updates all dependencies to latest versions which support running on Node v10 and v12. 
  - Its possible that earlier Node versions also work but I did not test against them.
  - Package engine was updated accordingly to Node 10 or later.
- Updates grunt to v1.x
- Removed deprecated jscs rule
- All tests and linter passes

Fixes: https://github.com/sapegin/grunt-webfont/issues/394